### PR TITLE
Fix default mousebinds and allow modifier keys

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -156,6 +156,7 @@
         <mouse>
           <doubleClickTime>${toStr cfg.mouse.doubleClickTime}</doubleClickTime>
           <scrollFactor>${toStr cfg.mouse.scrollFactor}</scrollFactor>
+          ${if cfg.mouse.default then "<default/>" else ""}
           ${indent 4 (formatList (x: ''
             <context name="${toStr x.name}">
               ${indent 2 (formatList (y: ''
@@ -164,7 +165,7 @@
                 </mousebind>
               '') x.value)}
             </context>
-          '') (mapAttrsToList (n: v: {name=n;value=v;}) cfg.mouse.mousebinds))}${if cfg.mouse.default then "\n    <default/>" else ""}
+          '') (mapAttrsToList (n: v: {name=n;value=v;}) cfg.mouse.mousebinds))}
         </mouse>
         <touch deviceName="${toStr cfg.touch.deviceName}" mapToOutput="${toStr cfg.touch.mapToOutput}" />
         <tablet>

--- a/config/mouse.nix
+++ b/config/mouse.nix
@@ -18,7 +18,7 @@
       type = types.attrsOf (types.listOf (types.submodule {
         options = {
           button = mkOption {
-            type = types.enum [ "" "Left" "Middle" "Right" "Side" "Extra" "Forward" "Back" "Task" ]; 
+            type = types.nullOr types.str;
             default = "";
           };
           direction = mkOption {


### PR DESCRIPTION
First of all, thank you for this module! 

This PR fixes a couple of issues I noticed when setting up labwc.

- Moves the `<default />` bindings above user specified ones. The reason for this is so that the user can disable some default bindings without having to re-specify all of them. This is how the source rc.xml configuration is. When this is after the user bindings, it overrides any user-specified bindings which may conflict.
- Sets the mouse binding button to accept a string, rather than from a list of options. This is so that you can use a modifier key as part of the mouse binding. For example `W-Left` or `C-Right`. The downside of this change is that there is no more validation on what can be specified, but I felt it is a reasonable change since it would be too complicated to list every key combination in the enum list.